### PR TITLE
feat(census-api): require and send CENSUS_API_KEY on Census Data API requests

### DIFF
--- a/CENSUS_API_KEY.md
+++ b/CENSUS_API_KEY.md
@@ -1,0 +1,175 @@
+# Setting Up Your Census API Key
+
+As of **May 12, 2026**, the U.S. Census Bureau requires an API key on
+**every** request to `api.census.gov`. Pyncoda fetches its core inputs
+from that API, so without a key the workflow will stop with an error
+that looks like:
+
+```
+The Census Data API requires an API key. Set the CENSUS_API_KEY
+environment variable to a valid key. See CENSUS_API_KEY.md for free
+signup and setup steps.
+```
+
+The key is **free**, takes about a minute to request, and arrives
+instantly by email.
+
+---
+
+## Step 1 — Request a key
+
+Go to <https://api.census.gov/data/key_signup.html>, fill in the short
+form (organization name + email), and submit. The Census Bureau emails
+you a 40-character hexadecimal key. Treat it like a password — don't
+commit it to git or paste it into chat.
+
+---
+
+## Step 2 — Make the key available as an environment variable
+
+Pyncoda reads the key from the environment variable `CENSUS_API_KEY`.
+Pick the section below that matches your operating system.
+
+### macOS and Linux
+
+#### Option A — Set it for the current terminal only
+
+This is the quickest way to try things out. The variable disappears
+when you close the terminal.
+
+```bash
+export CENSUS_API_KEY=your-40-character-key-here
+```
+
+Verify it's set:
+
+```bash
+echo $CENSUS_API_KEY
+```
+
+#### Option B — Set it permanently (recommended for regular use)
+
+Add the same `export` line to your shell's startup file so every new
+terminal picks it up automatically.
+
+- **macOS (default zsh):** edit `~/.zshrc`
+- **Linux (bash):** edit `~/.bashrc` (or `~/.bash_profile` on some
+  setups)
+- **Either OS, fish shell:** run `set -Ux CENSUS_API_KEY your-key`
+  instead — `fish` persists universal variables for you.
+
+Example for zsh / bash:
+
+```bash
+echo 'export CENSUS_API_KEY=your-40-character-key-here' >> ~/.zshrc
+source ~/.zshrc            # apply to the current terminal
+```
+
+Open a new terminal and confirm with `echo $CENSUS_API_KEY`.
+
+---
+
+### Windows
+
+#### Option A — Command Prompt (current session only)
+
+```cmd
+set CENSUS_API_KEY=your-40-character-key-here
+```
+
+Verify:
+
+```cmd
+echo %CENSUS_API_KEY%
+```
+
+This lasts only until you close the Command Prompt window.
+
+#### Option B — PowerShell (current session only)
+
+```powershell
+$env:CENSUS_API_KEY = "your-40-character-key-here"
+```
+
+Verify:
+
+```powershell
+echo $env:CENSUS_API_KEY
+```
+
+#### Option C — Set it permanently via the Settings UI (recommended)
+
+1. Press **Windows key**, type **"environment variables"**, and select
+   **"Edit the system environment variables"**.
+2. In the dialog that opens, click the **Environment Variables…**
+   button at the bottom.
+3. Under **"User variables for <your username>"**, click **New…**.
+4. Set **Variable name** to `CENSUS_API_KEY` and **Variable value** to
+   your 40-character key. Click **OK** on each dialog.
+5. **Close and reopen** any terminals, IDEs (VS Code, PyCharm), or
+   Jupyter sessions so they pick up the new variable.
+
+Verify in a fresh PowerShell window:
+
+```powershell
+echo $env:CENSUS_API_KEY
+```
+
+#### Option D — Set it permanently via PowerShell (no GUI)
+
+```powershell
+[System.Environment]::SetEnvironmentVariable(
+    "CENSUS_API_KEY",
+    "your-40-character-key-here",
+    "User"
+)
+```
+
+Close and reopen your terminal afterward.
+
+---
+
+## Step 3 — Make sure your IDE or Jupyter sees the variable
+
+A common source of confusion: you set the variable in a terminal, but
+your IDE or Jupyter notebook was already running and inherited the
+**old** environment.
+
+- **VS Code / PyCharm:** fully quit the application and reopen it
+  after setting the variable.
+- **Jupyter Notebook / Lab:** stop the kernel and the notebook
+  server, then restart both from a terminal that has the variable
+  set.
+- **Quick sanity check inside Python:**
+
+  ```python
+  import os
+  print(os.environ.get("CENSUS_API_KEY"))
+  ```
+
+  If this prints `None`, the variable isn't visible to your Python
+  process yet — restart the IDE/Jupyter from a fresh terminal.
+
+---
+
+## Troubleshooting
+
+- **"The Census Data API requires an API key"** — the variable is not
+  set in the environment your Python process inherited. See Step 3.
+- **"Census API rejected the CENSUS_API_KEY"** — the variable is set
+  but the key itself is wrong (typo, extra whitespace, or revoked).
+  Re-check the key in your activation email, or request a new one.
+- **The key still doesn't work after a fresh terminal** — make sure
+  you didn't wrap the value in quotes inside `.zshrc` / `.bashrc` if
+  the key contains no special characters; `export CENSUS_API_KEY=abc…`
+  is enough. Stray quotes become part of the value.
+
+---
+
+## Security note
+
+- Don't commit your key to git. Add `CENSUS_API_KEY` (the file, if you
+  ever save it locally) and any `.env` files to `.gitignore`.
+- Don't paste the key into screenshots, issues, or chat logs. If you
+  do, treat it as compromised and request a new one — old keys can be
+  rotated by requesting a fresh signup with the same email.

--- a/pyncoda/CommunitySourceData/api_census_gov/acg_01a_BaseInventory.py
+++ b/pyncoda/CommunitySourceData/api_census_gov/acg_01a_BaseInventory.py
@@ -382,22 +382,57 @@ class BaseInventory():
         api_hyperlink = ('https://api.census.gov/data/' + vintage + '/'+dataset_name + '?get=' + get_vars +
                         '&in=state:' + state + '&in=county:' + county + '&for='+for_geography)
 
+        # As of 2026-05-12 the Census Data API requires an API key on
+        # every request. Read it from the environment so it never ends
+        # up in source control or in logs. See CENSUS_API_KEY.md at the
+        # repository root for how to obtain and set the key.
+        census_api_key = os.environ.get('CENSUS_API_KEY')
+        if not census_api_key:
+            raise Exception(
+                "The Census Data API requires an API key. Set the "
+                "CENSUS_API_KEY environment variable to a valid key. "
+                "See CENSUS_API_KEY.md for free signup and setup steps."
+            )
+
+        # Print the URL without the key so it doesn't leak into logs.
         print("       Census API data from: " + api_hyperlink)
 
-        # Obtain Census API JSON Data
-        apijson = requests.get(api_hyperlink)
+        # Append the key only for the actual request. allow_redirects is
+        # disabled so that the missing-key 302 to .../missing_key.html
+        # surfaces as a hard error here instead of leaking through as an
+        # HTML "200 OK" body that later breaks JSON parsing.
+        apijson = requests.get(
+            api_hyperlink + '&key=' + census_api_key,
+            allow_redirects=False,
+        )
+
+        if (apijson.status_code == 302
+                and apijson.headers.get('X-DataWebAPI-KeyError')):
+            raise Exception(
+                "Census API rejected the CENSUS_API_KEY (missing or "
+                "invalid). Verify the value of the CENSUS_API_KEY "
+                "environment variable; see CENSUS_API_KEY.md."
+            )
         if apijson.status_code != 200:
-            print("API status code:",apijson.status_code)
+            print("API status code:", apijson.status_code)
             error_msg = "Failed to download the data from Census API."
             #logger.error(error_msg)
             raise Exception(error_msg)
 
+        try:
+            payload = apijson.json()
+        except ValueError as e:
+            raise Exception(
+                "Census API returned a non-JSON response "
+                f"({e}). First 200 bytes: {apijson.text[:200]!r}"
+            )
+
         # Convert the requested json into pandas dataframe
-        df = pd.DataFrame(columns=apijson.json()[0], data=apijson.json()[1:])
-        
+        df = pd.DataFrame(columns=payload[0], data=payload[1:])
+
         # save json as text file
         with open(json_filepath, 'w') as convert_file:
-            json.dump(apijson.json(),convert_file)
+            json.dump(payload, convert_file)
 
         return df
 


### PR DESCRIPTION
The Census Data API began requiring an API key on every request as of 2026-05-12. Unauthenticated calls now 302-redirect to an HTML "missing key" page, which requests silently follows and returns as a 200, breaking JSON parsing with a cryptic "Expecting value: line 2 column 1" error.

Read the key from the CENSUS_API_KEY environment variable and append it to each request in obtain_census_api. Disable redirect-following so the missing-key 302 is caught directly, detect the X-DataWebAPI-KeyError header to flag an invalid key, and wrap .json() to report non-JSON responses clearly. Keep the key out of logs by printing the URL without it. Add CENSUS_API_KEY.md with signup and env-var setup instructions for macOS, Linux, and Windows.