### PR TITLE
Make figures/codebook optional and fix block unit-surplus distribution

### DIFF
--- a/CENSUS_API_KEY.md
+++ b/CENSUS_API_KEY.md
@@ -1,0 +1,175 @@
+# Setting Up Your Census API Key
+
+As of **May 12, 2026**, the U.S. Census Bureau requires an API key on
+**every** request to `api.census.gov`. Pyncoda fetches its core inputs
+from that API, so without a key the workflow will stop with an error
+that looks like:
+
+```
+The Census Data API requires an API key. Set the CENSUS_API_KEY
+environment variable to a valid key. See CENSUS_API_KEY.md for free
+signup and setup steps.
+```
+
+The key is **free**, takes about a minute to request, and arrives
+instantly by email.
+
+---
+
+## Step 1 — Request a key
+
+Go to <https://api.census.gov/data/key_signup.html>, fill in the short
+form (organization name + email), and submit. The Census Bureau emails
+you a 40-character hexadecimal key. Treat it like a password — don't
+commit it to git or paste it into chat.
+
+---
+
+## Step 2 — Make the key available as an environment variable
+
+Pyncoda reads the key from the environment variable `CENSUS_API_KEY`.
+Pick the section below that matches your operating system.
+
+### macOS and Linux
+
+#### Option A — Set it for the current terminal only
+
+This is the quickest way to try things out. The variable disappears
+when you close the terminal.
+
+```bash
+export CENSUS_API_KEY=your-40-character-key-here
+```
+
+Verify it's set:
+
+```bash
+echo $CENSUS_API_KEY
+```
+
+#### Option B — Set it permanently (recommended for regular use)
+
+Add the same `export` line to your shell's startup file so every new
+terminal picks it up automatically.
+
+- **macOS (default zsh):** edit `~/.zshrc`
+- **Linux (bash):** edit `~/.bashrc` (or `~/.bash_profile` on some
+  setups)
+- **Either OS, fish shell:** run `set -Ux CENSUS_API_KEY your-key`
+  instead — `fish` persists universal variables for you.
+
+Example for zsh / bash:
+
+```bash
+echo 'export CENSUS_API_KEY=your-40-character-key-here' >> ~/.zshrc
+source ~/.zshrc            # apply to the current terminal
+```
+
+Open a new terminal and confirm with `echo $CENSUS_API_KEY`.
+
+---
+
+### Windows
+
+#### Option A — Command Prompt (current session only)
+
+```cmd
+set CENSUS_API_KEY=your-40-character-key-here
+```
+
+Verify:
+
+```cmd
+echo %CENSUS_API_KEY%
+```
+
+This lasts only until you close the Command Prompt window.
+
+#### Option B — PowerShell (current session only)
+
+```powershell
+$env:CENSUS_API_KEY = "your-40-character-key-here"
+```
+
+Verify:
+
+```powershell
+echo $env:CENSUS_API_KEY
+```
+
+#### Option C — Set it permanently via the Settings UI (recommended)
+
+1. Press **Windows key**, type **"environment variables"**, and select
+   **"Edit the system environment variables"**.
+2. In the dialog that opens, click the **Environment Variables…**
+   button at the bottom.
+3. Under **"User variables for <your username>"**, click **New…**.
+4. Set **Variable name** to `CENSUS_API_KEY` and **Variable value** to
+   your 40-character key. Click **OK** on each dialog.
+5. **Close and reopen** any terminals, IDEs (VS Code, PyCharm), or
+   Jupyter sessions so they pick up the new variable.
+
+Verify in a fresh PowerShell window:
+
+```powershell
+echo $env:CENSUS_API_KEY
+```
+
+#### Option D — Set it permanently via PowerShell (no GUI)
+
+```powershell
+[System.Environment]::SetEnvironmentVariable(
+    "CENSUS_API_KEY",
+    "your-40-character-key-here",
+    "User"
+)
+```
+
+Close and reopen your terminal afterward.
+
+---
+
+## Step 3 — Make sure your IDE or Jupyter sees the variable
+
+A common source of confusion: you set the variable in a terminal, but
+your IDE or Jupyter notebook was already running and inherited the
+**old** environment.
+
+- **VS Code / PyCharm:** fully quit the application and reopen it
+  after setting the variable.
+- **Jupyter Notebook / Lab:** stop the kernel and the notebook
+  server, then restart both from a terminal that has the variable
+  set.
+- **Quick sanity check inside Python:**
+
+  ```python
+  import os
+  print(os.environ.get("CENSUS_API_KEY"))
+  ```
+
+  If this prints `None`, the variable isn't visible to your Python
+  process yet — restart the IDE/Jupyter from a fresh terminal.
+
+---
+
+## Troubleshooting
+
+- **"The Census Data API requires an API key"** — the variable is not
+  set in the environment your Python process inherited. See Step 3.
+- **"Census API rejected the CENSUS_API_KEY"** — the variable is set
+  but the key itself is wrong (typo, extra whitespace, or revoked).
+  Re-check the key in your activation email, or request a new one.
+- **The key still doesn't work after a fresh terminal** — make sure
+  you didn't wrap the value in quotes inside `.zshrc` / `.bashrc` if
+  the key contains no special characters; `export CENSUS_API_KEY=abc…`
+  is enough. Stray quotes become part of the value.
+
+---
+
+## Security note
+
+- Don't commit your key to git. Add `CENSUS_API_KEY` (the file, if you
+  ever save it locally) and any `.env` files to `.gitignore`.
+- Don't paste the key into screenshots, issues, or chat logs. If you
+  do, treat it as compromised and request a new one — old keys can be
+  rotated by requesting a fresh signup with the same email.

--- a/pyncoda/CommunitySourceData/api_census_gov/acg_01a_BaseInventory.py
+++ b/pyncoda/CommunitySourceData/api_census_gov/acg_01a_BaseInventory.py
@@ -382,22 +382,57 @@ class BaseInventory():
         api_hyperlink = ('https://api.census.gov/data/' + vintage + '/'+dataset_name + '?get=' + get_vars +
                         '&in=state:' + state + '&in=county:' + county + '&for='+for_geography)
 
+        # As of 2026-05-12 the Census Data API requires an API key on
+        # every request. Read it from the environment so it never ends
+        # up in source control or in logs. See CENSUS_API_KEY.md at the
+        # repository root for how to obtain and set the key.
+        census_api_key = os.environ.get('CENSUS_API_KEY')
+        if not census_api_key:
+            raise Exception(
+                "The Census Data API requires an API key. Set the "
+                "CENSUS_API_KEY environment variable to a valid key. "
+                "See CENSUS_API_KEY.md for free signup and setup steps."
+            )
+
+        # Print the URL without the key so it doesn't leak into logs.
         print("       Census API data from: " + api_hyperlink)
 
-        # Obtain Census API JSON Data
-        apijson = requests.get(api_hyperlink)
+        # Append the key only for the actual request. allow_redirects is
+        # disabled so that the missing-key 302 to .../missing_key.html
+        # surfaces as a hard error here instead of leaking through as an
+        # HTML "200 OK" body that later breaks JSON parsing.
+        apijson = requests.get(
+            api_hyperlink + '&key=' + census_api_key,
+            allow_redirects=False,
+        )
+
+        if (apijson.status_code == 302
+                and apijson.headers.get('X-DataWebAPI-KeyError')):
+            raise Exception(
+                "Census API rejected the CENSUS_API_KEY (missing or "
+                "invalid). Verify the value of the CENSUS_API_KEY "
+                "environment variable; see CENSUS_API_KEY.md."
+            )
         if apijson.status_code != 200:
-            print("API status code:",apijson.status_code)
+            print("API status code:", apijson.status_code)
             error_msg = "Failed to download the data from Census API."
             #logger.error(error_msg)
             raise Exception(error_msg)
 
+        try:
+            payload = apijson.json()
+        except ValueError as e:
+            raise Exception(
+                "Census API returned a non-JSON response "
+                f"({e}). First 200 bytes: {apijson.text[:200]!r}"
+            )
+
         # Convert the requested json into pandas dataframe
-        df = pd.DataFrame(columns=apijson.json()[0], data=apijson.json()[1:])
-        
+        df = pd.DataFrame(columns=payload[0], data=payload[1:])
+
         # save json as text file
         with open(json_filepath, 'w') as convert_file:
-            json.dump(apijson.json(),convert_file)
+            json.dump(payload, convert_file)
 
         return df
 

--- a/pyncoda/ncoda_02d_addresspoint.py
+++ b/pyncoda/ncoda_02d_addresspoint.py
@@ -178,8 +178,13 @@ def predict_residential_addresspoints(building_to_block_gdf,
     print(len_bldg_df,"buildings with error 5. HU > 0, AP = 0.")
 
     # Calculate sum of Residential Area By Block
+    # Use all residential buildings (residentialAP1 >= 1), not just single-unit
+    # buildings, so the block surplus is redistributed across every residential
+    # building weighted by floor area. Using '== 1' here forced all extra units
+    # onto single-unit buildings and excluded multi-unit buildings entirely.
     bldg_df_round2['Res_Area'] = 0
-    condition = (bldg_df_round2['residentialAP1'] == 1)
+    # condition = (bldg_df_round2['residentialAP1'] == 1)
+    condition = (bldg_df_round2['residentialAP1'] >= 1)
     # Fill non-finite values in building_area_var with 0, then cast to int64
     bldg_df_round2.loc[condition, 'Res_Area'] = bldg_df_round2[
         building_area_var

--- a/pyncoda/ncoda_07a_generate_hui.py
+++ b/pyncoda/ncoda_07a_generate_hui.py
@@ -71,7 +71,9 @@ class generate_hui_functions():
             outputfolder: str ="",
             outputfolders = {},
             savefiles: bool = True,
-            use_incore: bool = True):
+            use_incore: bool = True,
+            generate_figures: bool = True,
+            generate_codebook: bool = True):
 
         self.communities = communities
         self.seed = seed
@@ -82,6 +84,11 @@ class generate_hui_functions():
         self.outputfolders = outputfolders
         self.savefiles = savefiles
         self.use_incore = use_incore
+        # Optional outputs. Defaults preserve the full IN-CORE workflow.
+        # Callers that only need the raw inventory (e.g. BRAILS) can set
+        # these to False to skip figure and PDF codebook generation.
+        self.generate_figures = generate_figures
+        self.generate_codebook = generate_codebook
 
 
         # Save Outputfolder - due to long folder name paths output saved to folder with shorter name
@@ -201,41 +208,43 @@ class generate_hui_functions():
 
             # Generate figures for explore data
             figures_list = []
-            for by_var in ["race","hispan","family"]:
-                try:
-                    income_by_var_figure = income_distribution(input_df = hui_incore_df,
-                                    variable = "randincome",
-                                    by_variable = by_var,
-                                    datastructure = incore_v2_DataStructure,
-                                    communities= self.communities,
-                                    community = community,
-                                    year = self.basevintage,
-                                    outputfolders = outputfolders)
-                    filename = income_by_var_figure+".png"
-                    figures_list.append(filename)
-                except Exception as e:
-                    print(f'Error making figure for {by_var}: {e}')
-
-            # Paths for codebook text
-            CommunitySourceData_filepath = os.path.join('pyncoda', 'CommunitySourceData', 'api_census_gov')
-            keyterms_filepath = os.path.join(CommunitySourceData_filepath, 'acg_00a_keyterms.md')
-
-            projectoverview_filepath = os.path.join('pyncoda', 'ncoda_00a_projectoverview.md')
+            if self.generate_figures:
+                for by_var in ["race","hispan","family"]:
+                    try:
+                        income_by_var_figure = income_distribution(input_df = hui_incore_df,
+                                        variable = "randincome",
+                                        by_variable = by_var,
+                                        datastructure = incore_v2_DataStructure,
+                                        communities= self.communities,
+                                        community = community,
+                                        year = self.basevintage,
+                                        outputfolders = outputfolders)
+                        filename = income_by_var_figure+".png"
+                        figures_list.append(filename)
+                    except Exception as e:
+                        print(f'Error making figure for {by_var}: {e}')
 
             # Create PDF Codebook
-            pdfcodebook = codebook(input_df = hui_incore_df_fixed,
-                    header_title = 'Housing Unit Inventory',
-                    datastructure = incore_v2_DataStructure,
-                    projectoverview = projectoverview_filepath,
-                    keyterms = keyterms_filepath,
-                    communities = self.communities,
-                    community = community,
-                    year = self.basevintage,
-                    output_filename = output_filename,
-                    outputfolders = outputfolders,
-                    figures = figures_list,
-                    image_path = 'IN-CORE_HRRC_Banner.png')
-            pdfcodebook.create_codebook()
+            if self.generate_codebook:
+                # Paths for codebook text
+                CommunitySourceData_filepath = os.path.join('pyncoda', 'CommunitySourceData', 'api_census_gov')
+                keyterms_filepath = os.path.join(CommunitySourceData_filepath, 'acg_00a_keyterms.md')
+
+                projectoverview_filepath = os.path.join('pyncoda', 'ncoda_00a_projectoverview.md')
+
+                pdfcodebook = codebook(input_df = hui_incore_df_fixed,
+                        header_title = 'Housing Unit Inventory',
+                        datastructure = incore_v2_DataStructure,
+                        projectoverview = projectoverview_filepath,
+                        keyterms = keyterms_filepath,
+                        communities = self.communities,
+                        community = community,
+                        year = self.basevintage,
+                        output_filename = output_filename,
+                        outputfolders = outputfolders,
+                        figures = figures_list,
+                        image_path = 'IN-CORE_HRRC_Banner.png')
+                pdfcodebook.create_codebook()
 
             # Upload CSV file to IN-CORE and save dataset_id
             # note you have to put the correct dataType as well as format

--- a/pyncoda/ncoda_07i_process_communities.py
+++ b/pyncoda/ncoda_07i_process_communities.py
@@ -43,7 +43,9 @@ class process_community_workflow():
             census_tracts: list = None,
             import_hui_path: str = None,
             export_hui_path: str = None,
-            force_hua_rerun: bool = False):
+            force_hua_rerun: bool = False,
+            generate_figures: bool = True,
+            generate_codebook: bool = True):
         """
         Initialize the process_community_workflow class.
 
@@ -65,6 +67,12 @@ class process_community_workflow():
         - force_hua_rerun: If True, always perform the housing unit allocation from scratch, even if
                           previously saved data exists. This affects only the probabilistic assignment
                           of housing units to buildings, not the generation of the housing unit inventory.
+        - generate_figures: If True (default), generate the explore-data figures for the housing
+                          unit inventory. Set to False to skip figure generation when only the raw
+                          inventory is needed (e.g. when called from BRAILS).
+        - generate_codebook: If True (default), generate the PDF codebook for the housing unit
+                          inventory. Set to False to skip codebook generation when only the raw
+                          inventory is needed (e.g. when called from BRAILS).
         """
 
         self.communities = communities
@@ -79,6 +87,8 @@ class process_community_workflow():
         self.import_hui_path = import_hui_path
         self.export_hui_path = export_hui_path
         self.force_hua_rerun = force_hua_rerun
+        self.generate_figures = generate_figures
+        self.generate_codebook = generate_codebook
 
 
     def generate_hui(self, communities, use_incore):
@@ -104,7 +114,9 @@ class process_community_workflow():
                                 version_text=   self.version_text,
                                 basevintage=    self.basevintage,
                                 outputfolder=   self.outputfolder,
-                                use_incore=     use_incore
+                                use_incore=     use_incore,
+                                generate_figures=   self.generate_figures,
+                                generate_codebook=  self.generate_codebook
                                 )
 
             hui_dataset_id = generate_hui_df.generate_hui_v2_for_incore()


### PR DESCRIPTION
## Summary

Two small, independent changes that let pyncoda run cleanly when driven
by BRAILS and correct a unit-distribution issue. Full rationale are in the 
individual commit messages; the main points:

1. **Optional figure & PDF codebook generation**
   Adds `generate_figures` and `generate_codebook` flags to
   `generate_hui_functions` (ncoda_07a) and `process_community_workflow`
   (ncoda_07i). Both default to `True`, so direct pyncoda runs are unchanged.
   These outputs were previously tied to `use_incore`, which conflated
   "am I uploading to IN-CORE" with "do I want figures and a codebook."
   BRAILS only needs the raw assignment and can't run effectively with
   them on, so it passes `False`.

2. **Fix block housing-unit surplus distribution**
   In `predict_residential_addresspoints` (round 2), the residential-area
   weight used to spread a block's surplus units was assigned only to
   single-unit buildings (`== 1`). I believe this is a bug: it forced the
   surplus onto single-family homes and excluded multi-unit buildings, and
   in blocks with no single-unit building it produced a divide-by-zero that
   collapsed capacity and left units unassigned. Changed to `>= 1`, matching
   the two sibling residential tests in the same function.

## Verification

Validated on BRAILS housing-unit allocation runs (Alameda County, CA, 2020):
the addpt fix eliminated all blocks that had buildings yet still leaked units,
while per-block Census totals are unchanged.